### PR TITLE
fix(server/posts): adding new checks in services

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -32,6 +32,7 @@
     "@types/bcrypt": "^5.0.0",
     "@types/jest": "^29.5.2",
     "@types/jsonwebtoken": "^9.0.2",
+    "dotenv": "^16.3.1",
     "eslint": "^8.44.0",
     "jest": "^29.6.0",
     "prisma": "^4.16.2",

--- a/server/src/controllers/post.controller.ts
+++ b/server/src/controllers/post.controller.ts
@@ -84,7 +84,7 @@ const PostController = {
   createPost: async (request: FastifyRequest, reply: FastifyReply) => {
     const bodySchema = z
       .object({
-        subtitle: z.string(),
+        subtitle: z.string().nonempty('subtitle is required'),
         userId: z.string().nonempty('userId is required'),
         imageId: z.string().nonempty('imageId is required'),
       })
@@ -154,7 +154,7 @@ const PostController = {
 
     const bodySchema = z
       .object({
-        subtitle: z.string(),
+        subtitle: z.string().optional(),
         userId: z.string().optional(),
         imageId: z.string().optional(),
       })

--- a/server/src/routes/post.routes.ts
+++ b/server/src/routes/post.routes.ts
@@ -10,7 +10,7 @@ const PostRoutes = (
   fastify.get('/posts/:id', options, PostController.getPostById)
   fastify.get('/posts/user/:userId', options, PostController.getPostsByUserId)
   fastify.post('/posts', options, PostController.createPost)
-  fastify.put('/posts/:id', options, PostController.updatePost)
+  fastify.patch('/posts/:id', options, PostController.updatePost)
   fastify.delete('/posts/:id', options, PostController.deletePost)
   done()
 }

--- a/server/src/services/post.service.ts
+++ b/server/src/services/post.service.ts
@@ -95,6 +95,26 @@ const PostService = (
         payload: undefined,
       }
     }
+    if (post.userId) {
+      const existingUser = await userRepository.getUserById(post.userId)
+      if (!existingUser) {
+        return {
+          ok: false,
+          message: `User #${post.userId} not found`,
+          payload: undefined,
+        }
+      }
+    }
+    if (post.imageId) {
+      const existingImage = await imageRepository.getImage(post.imageId)
+      if (!existingImage) {
+        return {
+          ok: false,
+          message: `Image #${post.imageId} not found`,
+          payload: undefined,
+        }
+      }
+    }
     const updatedPost = await postRepository.updatePost(id, post)
     return {
       ok: true,

--- a/server/tests/integration/repositories/prisma/post.repository.spec.ts
+++ b/server/tests/integration/repositories/prisma/post.repository.spec.ts
@@ -194,6 +194,72 @@ describe('PrismaPostRepository', () => {
     ).rejects.toThrow()
   })
 
+  it('should be able to update a post with the same subtitle', async () => {
+    const post = {
+      subtitle: 'Teste',
+      userId,
+      imageId,
+    }
+    const { id } = await repository.createPost(post)
+    const updated = await repository.updatePost(id, {
+      subtitle: 'Teste',
+    })
+
+    expect(updated).toBeTruthy()
+    expect(updated).toStrictEqual({
+      id,
+      subtitle: 'Teste',
+      userId: post.userId,
+      imageId: post.imageId,
+      createdAt: expect.any(Date),
+      updatedAt: expect.any(Date),
+    })
+  })
+
+  it('should be able to update a post with the same image id', async () => {
+    const post = {
+      subtitle: 'Teste',
+      userId,
+      imageId,
+    }
+    const { id } = await repository.createPost(post)
+    const updated = await repository.updatePost(id, {
+      imageId,
+    })
+
+    expect(updated).toBeTruthy()
+    expect(updated).toStrictEqual({
+      id,
+      subtitle: post.subtitle,
+      userId: post.userId,
+      imageId: post.imageId,
+      createdAt: expect.any(Date),
+      updatedAt: expect.any(Date),
+    })
+  })
+
+  it('should be able to update a post with the same user id', async () => {
+    const post = {
+      subtitle: 'Teste',
+      userId,
+      imageId,
+    }
+    const { id } = await repository.createPost(post)
+    const updated = await repository.updatePost(id, {
+      userId,
+    })
+
+    expect(updated).toBeTruthy()
+    expect(updated).toStrictEqual({
+      id,
+      subtitle: post.subtitle,
+      userId: post.userId,
+      imageId: post.imageId,
+      createdAt: expect.any(Date),
+      updatedAt: expect.any(Date),
+    })
+  })
+
   it('should delete a post', async () => {
     const post = {
       subtitle: 'Teste',

--- a/server/tests/integration/services/image.service.spec.ts
+++ b/server/tests/integration/services/image.service.spec.ts
@@ -247,6 +247,10 @@ describe('PrismaImageService', () => {
     userId = id
   })
 
+  afterAll(async () => {
+    await PrismaUserRepository.deleteUser(userId)
+  })
+
   afterEach(async () => {
     await clearImagesPrisma()
   })

--- a/server/tests/integration/services/post.service.spec.ts
+++ b/server/tests/integration/services/post.service.spec.ts
@@ -265,6 +265,48 @@ describe('MemoryPostService', () => {
       expect(result.message).toContain('not found')
       expect(result.payload).toBeUndefined()
     })
+
+    it('should not be able to update a post with a invalid user id', async () => {
+      const post = {
+        subtitle: 'Teste',
+        userId,
+        imageId,
+      }
+
+      const created = await service.createPost(post)
+
+      if (!created.payload) throw new Error('Post not created')
+
+      const result = await service.updatePost(created.payload.id, {
+        userId: 'invalid',
+      })
+
+      expect(result.ok).toBeFalsy()
+      expect(result.message).toContain('User')
+      expect(result.message).toContain('not found')
+      expect(result.payload).toBeUndefined()
+    })
+
+    it('should not be able to update a post with a invalid image id', async () => {
+      const post = {
+        subtitle: 'Teste',
+        userId,
+        imageId,
+      }
+
+      const created = await service.createPost(post)
+
+      if (!created.payload) throw new Error('Post not created')
+
+      const result = await service.updatePost(created.payload.id, {
+        imageId: 'invalid',
+      })
+
+      expect(result.ok).toBeFalsy()
+      expect(result.message).toContain('Image')
+      expect(result.message).toContain('not found')
+      expect(result.payload).toBeUndefined()
+    })
   })
 
   describe('delete', () => {
@@ -329,21 +371,13 @@ describe('PrismaPostService', () => {
   })
 
   afterAll(async () => {
-    await prisma.image.delete({
-      where: {
-        id: imageId,
-      },
-    })
+    await prisma.image.deleteMany()
 
-    await prisma.user.delete({
-      where: {
-        id: userId,
-      },
-    })
+    await prisma.user.deleteMany()
   })
 
-  afterEach(() => {
-    clearPostsPrisma()
+  afterEach(async () => {
+    await clearPostsPrisma()
   })
 
   describe('create', () => {
@@ -559,6 +593,48 @@ describe('PrismaPostService', () => {
 
       expect(result.ok).toBeFalsy()
       expect(result.message).toContain('Post')
+      expect(result.message).toContain('not found')
+      expect(result.payload).toBeUndefined()
+    })
+
+    it('should not be able to update a post with a invalid user id', async () => {
+      const post = {
+        subtitle: 'Teste',
+        userId,
+        imageId,
+      }
+
+      const created = await service.createPost(post)
+
+      if (!created.payload) throw new Error('Post not created')
+
+      const result = await service.updatePost(created.payload.id, {
+        userId: 'invalid',
+      })
+
+      expect(result.ok).toBeFalsy()
+      expect(result.message).toContain('User')
+      expect(result.message).toContain('not found')
+      expect(result.payload).toBeUndefined()
+    })
+
+    it('should not be able to update a post with a invalid image id', async () => {
+      const post = {
+        subtitle: 'Teste',
+        userId,
+        imageId,
+      }
+
+      const created = await service.createPost(post)
+
+      if (!created.payload) throw new Error('Post not created')
+
+      const result = await service.updatePost(created.payload.id, {
+        imageId: 'invalid',
+      })
+
+      expect(result.ok).toBeFalsy()
+      expect(result.message).toContain('Image')
       expect(result.message).toContain('not found')
       expect(result.payload).toBeUndefined()
     })

--- a/server/tests/unit/repositories/memory/post.repository.spec.ts
+++ b/server/tests/unit/repositories/memory/post.repository.spec.ts
@@ -157,6 +157,69 @@ describe('MemoryPostRepository', () => {
       }),
     ).rejects.toThrow()
   })
+  it('should be able to update a post with the same subtitle', async () => {
+    const post = {
+      subtitle: 'Post Title',
+      userId: 'post-id',
+      imageId: 'image-id',
+    }
+    const created = await repository.createPost(post)
+    const { id } = created
+    const updated = await repository.updatePost(id, {
+      subtitle: 'Post Title',
+    })
+    expect(updated).toBeTruthy()
+    expect(updated).toStrictEqual({
+      id,
+      subtitle: 'Post Title',
+      userId: 'post-id',
+      imageId: 'image-id',
+      createdAt: expect.any(Date),
+      updatedAt: expect.any(Date),
+    })
+  })
+  it('should be able to update a post with the same image id', async () => {
+    const post = {
+      subtitle: 'Post Title',
+      userId: 'post-id',
+      imageId: 'image-id',
+    }
+    const created = await repository.createPost(post)
+    const { id } = created
+    const updated = await repository.updatePost(id, {
+      imageId: 'image-id',
+    })
+    expect(updated).toBeTruthy()
+    expect(updated).toStrictEqual({
+      id,
+      subtitle: 'Post Title',
+      userId: 'post-id',
+      imageId: 'image-id',
+      createdAt: expect.any(Date),
+      updatedAt: expect.any(Date),
+    })
+  })
+  it('should be able to update a post with the same user id', async () => {
+    const post = {
+      subtitle: 'Post Title',
+      userId: 'post-id',
+      imageId: 'image-id',
+    }
+    const created = await repository.createPost(post)
+    const { id } = created
+    const updated = await repository.updatePost(id, {
+      userId: 'post-id',
+    })
+    expect(updated).toBeTruthy()
+    expect(updated).toStrictEqual({
+      id,
+      subtitle: 'Post Title',
+      userId: 'post-id',
+      imageId: 'image-id',
+      createdAt: expect.any(Date),
+      updatedAt: expect.any(Date),
+    })
+  })
   it('should delete a post', async () => {
     const post = {
       subtitle: 'Post Title',


### PR DESCRIPTION
# Resolve os problemas da issue 61:

- Não permite atualização de post com id de usuário inválido
- Não permite atualização de post com id de imagem inválido
- Retorna o post completo ao atualizar

